### PR TITLE
Add CrewAI-based test analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Agente de Qualidade
+
+Este projeto demonstra como utilizar a biblioteca **CrewAI** com o modelo da Azure OpenAI para analisar arquivos de teste em um projeto Python.
+
+## Pré‑requisitos
+
+- Python 3.11+
+- Dependências listadas em `requirements.txt`
+- Variáveis de ambiente configuradas para acesso ao Azure OpenAI:
+  - `AZURE_OPENAI_KEY`
+  - `AZURE_OPENAI_ENDPOINT`
+  - `AZURE_OPENAI_DEPLOYMENT`
+  - `AZURE_OPENAI_API_VERSION` (opcional)
+
+## Instalação
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+Execute o script principal informando o diretório do projeto a ser analisado:
+
+```bash
+python -m src.main caminho/do/projeto
+```
+
+O agente irá localizar todos os arquivos de teste (`test_*.py` ou `*_test.py`) e utilizará o Azure OpenAI para verificar se seguem boas práticas de mercado, gerando um relatório resumido.
+
+## Estrutura
+
+- `src/config.py` – configuração do acesso ao Azure OpenAI.
+- `src/tools.py` – ferramentas usadas pelos agentes (listar arquivos e ler conteúdo).
+- `src/analyzer.py` – ferramenta que utiliza o modelo da Azure OpenAI.
+- `src/main.py` – definição dos agentes, tarefas e ponto de entrada da aplicação.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+crewai
+openai

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1,0 +1,34 @@
+from typing import List
+import openai
+from crewai.tools.base_tool import BaseTool
+from .config import configure_openai
+
+
+class AzureTestReviewTool(BaseTool):
+    """Use Azure OpenAI to review python test code."""
+
+    name: str = "azure_test_review"
+    description: str = (
+        "Analyze the quality of python test code using Azure OpenAI and provide a concise report"
+    )
+
+    def _run(self, code: str) -> str:
+        deployment = configure_openai()
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are an expert QA engineer. Analyze the provided python test "
+                    "code and check if it follows best market practices. Suggest improvements "
+                    "when necessary. Return your feedback in a short paragraph followed by a "
+                    "rating from 1 to 10."
+                ),
+            },
+            {"role": "user", "content": code},
+        ]
+        response = openai.ChatCompletion.create(
+            engine=deployment,
+            messages=messages,
+            temperature=0,
+        )
+        return response.choices[0].message["content"].strip()

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,26 @@
+import os
+import openai
+
+
+def configure_openai() -> str:
+    """Configure OpenAI SDK to use Azure endpoints.
+
+    Returns the deployment name (engine) to be used when creating
+    chat completions.
+    Environment variables expected:
+        AZURE_OPENAI_KEY - API key.
+        AZURE_OPENAI_ENDPOINT - Base URL of the Azure OpenAI resource.
+        AZURE_OPENAI_DEPLOYMENT - Deployment/engine name.
+        AZURE_OPENAI_API_VERSION - API version (optional).
+    """
+    openai.api_type = "azure"
+    openai.api_key = os.getenv("AZURE_OPENAI_KEY")
+    openai.api_base = os.getenv("AZURE_OPENAI_ENDPOINT")
+    openai.api_version = os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview")
+    deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT")
+    if not all([openai.api_key, openai.api_base, deployment]):
+        raise EnvironmentError(
+            "Missing Azure OpenAI configuration. Please set AZURE_OPENAI_KEY, "
+            "AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_DEPLOYMENT environment variables."
+        )
+    return deployment

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import argparse
+from crewai import Agent, Task, Crew, Process
+
+from .tools import ListTestFilesTool, ReadFileTool
+from .analyzer import AzureTestReviewTool
+
+
+def build_crew(directory: str) -> Crew:
+    list_tool = ListTestFilesTool()
+    read_tool = ReadFileTool()
+    review_tool = AzureTestReviewTool()
+
+    finder = Agent(
+        role="Test Finder",
+        goal="Identify python test files",
+        backstory=(
+            "Experienced developer who knows how to navigate project structures to"
+            " locate test scripts."
+        ),
+        tools=[list_tool],
+    )
+
+    reviewer = Agent(
+        role="Test Reviewer",
+        goal="Check test code quality using Azure OpenAI",
+        backstory=(
+            "Seasoned QA engineer with knowledge of testing best practices and AI analysis."
+        ),
+        tools=[read_tool, review_tool],
+    )
+
+    collect = Task(
+        description="List all python test files in {directory}",
+        expected_output="A list of file paths",
+        agent=finder,
+    )
+
+    analyze = Task(
+        description=(
+            "Read each file returned by the previous task and provide a quality review"
+        ),
+        expected_output="A markdown report with feedback for each file",
+        agent=reviewer,
+        context=[collect],
+    )
+
+    crew = Crew(
+        agents=[finder, reviewer],
+        tasks=[collect, analyze],
+        process=Process.sequential,
+        verbose=True,
+    )
+    return crew
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze python test quality")
+    parser.add_argument("directory", help="Project directory to inspect")
+    args = parser.parse_args()
+
+    crew = build_crew(args.directory)
+    result = crew.kickoff({"directory": args.directory})
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools.py
+++ b/src/tools.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from typing import List
+from crewai.tools.base_tool import BaseTool
+
+
+class ListTestFilesTool(BaseTool):
+    """Tool to list Python test files within a directory."""
+
+    name: str = "list_test_files"
+    description: str = (
+        "List all python test files (test_*.py or *_test.py) in a directory recursively"
+    )
+
+    def _run(self, directory: str) -> List[str]:
+        base = Path(directory)
+        if not base.is_dir():
+            raise FileNotFoundError(f"{directory} is not a valid directory")
+        files = set()
+        for pattern in ("test_*.py", "*_test.py"):
+            for file in base.rglob(pattern):
+                files.add(str(file))
+        return sorted(files)
+
+
+class ReadFileTool(BaseTool):
+    """Tool to read a file content."""
+
+    name: str = "read_file"
+    description: str = "Read a text file using UTF-8 encoding"
+
+    def _run(self, filepath: str) -> str:
+        path = Path(filepath)
+        if not path.is_file():
+            raise FileNotFoundError(f"File {filepath} not found")
+        return path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- use Azure OpenAI via `configure_openai`
- implement CrewAI tools for listing files, reading files and analyzing tests
- wire agents and tasks in `main.py`
- document usage in README
- specify dependencies

## Testing
- `python -m src.main` *(fails: missing argument)*

------
https://chatgpt.com/codex/tasks/task_e_68449e8a6a208321b9d66da810ce4d8e